### PR TITLE
Refactor EntityHydrator to improve type handling and streamline value…

### DIFF
--- a/app/Core/ORM/EntityHydrator.php
+++ b/app/Core/ORM/EntityHydrator.php
@@ -16,13 +16,13 @@ class EntityHydrator
             foreach ($constructor->getParameters() as $param) {
                 $name = $param->getName();
                 $value = $data[$name] ?? null;
-                
                 $type = $param->getType();
-                if ($type && !$type->isBuiltin() && enum_exists($type->getName())) {
-                    $enumClass = $type->getName();
-                    $value = $enumClass::from($value);
+                if ($type instanceof \ReflectionNamedType) {
+                    $typeName = $type->getName();
+                    if (!$type->isBuiltin() && enum_exists($typeName)) {
+                        $value = $typeName::from($value);
+                    }
                 }
-                
                 $args[] = $value;
             }
         }
@@ -33,16 +33,15 @@ class EntityHydrator
             if ($reflection->hasProperty($key)) {
                 $prop = $reflection->getProperty($key);
                 $type = $prop->getType();
-                
-                if ($type && !$type->isBuiltin() && enum_exists($type->getName())) {
-                    $enumClass = $type->getName();
-                    $value = $enumClass::from($value);
+                if ($type instanceof \ReflectionNamedType) {
+                    $typeName = $type->getName();
+                    if (!$type->isBuiltin() && enum_exists($typeName)) {
+                        $value = $typeName::from($value);
+                    }
+                    if (($typeName === 'DateTimeImmutable' || $typeName === '\DateTimeImmutable') && is_string($value)) {
+                        $value = new \DateTimeImmutable($value);
+                    }
                 }
-                
-                if ($type && ($type->getName() === 'DateTimeImmutable' || $type->getName() === '\DateTimeImmutable') && is_string($value)) {
-                    $value = new \DateTimeImmutable($value);
-                }
-                
                 $prop->setAccessible(true);
                 $prop->setValue($instance, $value);
             }


### PR DESCRIPTION
This pull request refactors the `hydrate` method in `EntityHydrator.php` to improve type handling and readability. The changes primarily focus on replacing redundant code with a more concise and consistent approach when working with reflection types, enums, and `DateTimeImmutable`.

### Refactoring for type handling and readability:

* Updated the handling of parameter types in the constructor to explicitly check for `\ReflectionNamedType` instances, improving clarity and ensuring type safety.
* Simplified the logic for property type handling by consolidating checks for enums and `DateTimeImmutable` into a more structured and readable format. This includes replacing redundant calls to `getName()` with a single assignment to `typeName`.