### PR TITLE
Refactor EntityManager and EntityPersister to use EntityMetadata for …

### DIFF
--- a/app/Core/ORM/EntityManager.php
+++ b/app/Core/ORM/EntityManager.php
@@ -90,7 +90,7 @@ class EntityManager
     public function getEntityPersister(string $entityClass): EntityPersister
     {
         if (!isset($this->persisters[$entityClass])) {
-            $this->persisters[$entityClass] = new EntityPersister($this->connection, $entityClass);
+            $this->persisters[$entityClass] = new EntityPersister($this, $entityClass);
         }
         
         return $this->persisters[$entityClass];

--- a/app/Core/ORM/EntityMetadata.php
+++ b/app/Core/ORM/EntityMetadata.php
@@ -1,0 +1,53 @@
+<?php
+namespace App\Core\ORM;
+
+use ReflectionClass;
+
+class EntityMetadata
+{
+    private string $entityClass;
+    private string $tableName;
+    private array $properties = [];
+
+    public function __construct(string $entityClass)
+    {
+        $this->entityClass = $entityClass;
+        $this->tableName = $this->resolveTableName();
+        $this->properties = $this->resolveProperties();
+    }
+
+    public function getEntityClass(): string
+    {
+        return $this->entityClass;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    private function resolveTableName(): string
+    {
+        $reflection = new ReflectionClass($this->entityClass);
+        $attributes = $reflection->getAttributes(Table::class);
+        if (count($attributes) === 0) {
+            throw new \RuntimeException("Missing #[Table] attribute on class {$this->entityClass}");
+        }
+        return $attributes[0]->newInstance()->name;
+    }
+
+    private function resolveProperties(): array
+    {
+        $reflection = new ReflectionClass($this->entityClass);
+        $props = [];
+        foreach ($reflection->getProperties() as $property) {
+            $props[] = $property->getName();
+        }
+        return $props;
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the ORM layer, focusing on enhancing maintainability, modularity, and consistency. Key changes include the introduction of an `EntityMetadata` class for metadata management, refactoring the `EntityPersister` to depend on `EntityManager` instead of directly on `PDO`, and improving validation logic. These updates streamline the codebase and make it more robust for future extensions.

### Metadata Management Enhancements:
* Added a new `EntityMetadata` class to encapsulate entity metadata, including table name and properties, improving separation of concerns (`app/Core/ORM/EntityMetadata.php`).
* Updated `EntityPersister` to use `EntityMetadata` for resolving table names and properties instead of performing reflection directly (`app/Core/ORM/EntityPersister.php`). ([app/Core/ORM/EntityPersister.phpL9-R31](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L9-R31), Feb670d4L39R39)

### Dependency Refactoring:
* Refactored `EntityPersister` to depend on `EntityManager` instead of directly using `PDO`. This allows for better abstraction and reuse of the `EntityManager`'s connection handling (`app/Core/ORM/EntityPersister.php`). [[1]](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L9-R31) Feb670d4L39R39, [[2]](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L94-R99)

### Validation Improvements:
* Reintroduced and improved the `validate` method in `EntityPersister`, now iterating over all properties and checking for empty string values if the property type is `string` (`app/Core/ORM/EntityPersister.php`).

### Code Simplifications:
* Simplified various methods in `EntityPersister` by replacing direct `PDO` calls with `EntityManager::getConnection()` calls for consistency (`app/Core/ORM/EntityPersister.php`). (Feb670d4L39R39, [[1]](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L80-R59) [[2]](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L129-L138) [[3]](diffhunk://#diff-c1e81c190e324d9980a38eb858f39895212c2a09c6c2f19299058c6bfe4e70f2L183-R157)

### Minor Improvements:
* Enhanced the `insert` method to automatically set the inserted ID back to the entity if the `id` property exists (`app/Core/ORM/EntityPersister.php`).
* Adjusted the `update` method to exclude `id` from the `SET` clause dynamically, ensuring proper SQL syntax and execution (`app/Core/ORM/EntityPersister.php`).